### PR TITLE
[#174220931] Expected audiences configured to be required

### DIFF
--- a/src/main/java/com/dnastack/gatekeeper/acl/GatekeeperGatewayFilterFactory.java
+++ b/src/main/java/com/dnastack/gatekeeper/acl/GatekeeperGatewayFilterFactory.java
@@ -16,7 +16,6 @@ import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
@@ -42,10 +41,6 @@ import static java.lang.String.format;
 public class GatekeeperGatewayFilterFactory extends AbstractGatewayFilterFactory<GatekeeperConfig.Gateway> {
 
     public static final Pattern PATH_VARIABLE_PATTERN = Pattern.compile("\\{([a-zA-Z]*)\\}");
-
-    // Can't default to empty list when we specify value in application.yml
-    @Value("${gatekeeper.token.audiences:#{T(java.util.Collections).emptyList()}}")
-    private List<String> acceptedAudiences;
 
     @Autowired
     private TokenParser tokenParser;

--- a/src/main/java/com/dnastack/gatekeeper/token/TokenParser.java
+++ b/src/main/java/com/dnastack/gatekeeper/token/TokenParser.java
@@ -4,11 +4,14 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.JwtParser;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
+import javax.validation.constraints.NotEmpty;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,33 +19,34 @@ import static java.lang.String.format;
 
 @Slf4j
 @Component
+@Validated
+@ConfigurationProperties(prefix = "gatekeeper.token")
 public class TokenParser {
 
     @Autowired
     private JwtParser jwtParser;
-    // Can't default to empty list when we specify value in application.yml
-    @Value("${gatekeeper.token.audiences:#{T(java.util.Collections).emptyList()}}")
-    private List<String> acceptedAudiences;
+    @NotEmpty
+    @Setter
+    private List<String> audiences;
+
 
     public Jws<Claims> parseAndValidateJws(String authToken) throws JwtException, IllegalArgumentException {
         final Jws<Claims> jws = jwtParser.parseClaimsJws(authToken);
-        if (acceptedAudiences.isEmpty()) {
-            log.debug("Not validating token audience, because no audiences are configured.");
+
+        final String tokenAudience = Optional.of(jws)
+                .map(Jws::getBody)
+                .map(Claims::getAudience)
+                .orElseThrow(() -> new JwtException(
+                        "No audience specified in token."));
+        final Optional<String> validAudience = audiences.stream()
+                .filter(tokenAudience::equals)
+                .findAny();
+        if (validAudience.isPresent()) {
+            log.debug("Token audience successfully validated [{}]", validAudience.get());
         } else {
-            final String tokenAudience = Optional.of(jws)
-                                                 .map(Jws::getBody)
-                                                 .map(Claims::getAudience)
-                                                 .orElseThrow(() -> new JwtException(
-                                                         "No audience specified in token."));
-            final Optional<String> validAudience = acceptedAudiences.stream()
-                                                                    .filter(tokenAudience::equals)
-                                                                    .findAny();
-            if (validAudience.isPresent()) {
-                log.debug("Token audience successfully validated [{}]", validAudience.get());
-            } else {
-                throw new JwtException(format("Token audience [%s] is invalid.", tokenAudience));
-            }
+            throw new JwtException(format("Token audience [%s] is invalid.", tokenAudience));
         }
+
 
         log.info("Validated signature of inbound token {}", jws);
         return jws;


### PR DESCRIPTION
Hi @mbarkley I removed unused acceptedAudiences list from GatekeeperGatewayFilterFactory and change TokenParser to require audiences otherwise it fails to start. Should I change any configuration or something because I don't exactly know how gatekeeper is deployed and used. Thanks