### PR TITLE
[#178946834] Migrate deprecated features

### DIFF
--- a/src/main/java/com/dnastack/gatekeeper/config/JwtConfiguration.java
+++ b/src/main/java/com/dnastack/gatekeeper/config/JwtConfiguration.java
@@ -22,8 +22,9 @@ public class JwtConfiguration {
 
     @Bean
     public JwtParser jwtParser(ConfiguredSigningKeyResolver resolver) {
-        return Jwts.parser()
-                   .setSigningKeyResolver(resolver);
+        return Jwts.parserBuilder()
+            .setSigningKeyResolver(resolver)
+            .build();
     }
 
     @Bean

--- a/src/main/java/com/dnastack/gatekeeper/routing/LoginRouter.java
+++ b/src/main/java/com/dnastack/gatekeeper/routing/LoginRouter.java
@@ -121,7 +121,7 @@ public class LoginRouter {
                                      idpTokenRequest(request, code).flatMap(response -> downstreamTokenResponse(request,
                                                                                                                 response)))
                         .orElseGet(() -> badRequest().contentType(TEXT_PLAIN)
-                                                     .syncBody("Token request requires 'code' parameter."));
+                                                     .bodyValue("Token request requires 'code' parameter."));
     }
 
     private Mono<ServerResponse> downstreamTokenResponse(ServerRequest request, ClientResponse response) {
@@ -134,13 +134,13 @@ public class LoginRouter {
                            });
         } else {
             logTokenFailureInDetail(response);
-            return badRequest().contentType(TEXT_PLAIN).syncBody("Failed to acquire token.");
+            return badRequest().contentType(TEXT_PLAIN).bodyValue("Failed to acquire token.");
         }
     }
 
     private Mono<ServerResponse> failedUserTokenResponse(ClientResponse response) {
         logTokenFailureInDetail(response);
-        return status(INTERNAL_SERVER_ERROR).syncBody("Failed to parse token.");
+        return status(INTERNAL_SERVER_ERROR).bodyValue("Failed to parse token.");
     }
 
     private Mono<ServerResponse> successfulUserTokenResponse(ServerRequest request, TokenResponse tokens) {
@@ -222,7 +222,7 @@ public class LoginRouter {
                         .post()
                         .header("Authorization", authHeaderValue)
                         .contentType(APPLICATION_FORM_URLENCODED)
-                        .syncBody(formData)
+                        .bodyValue(formData)
                         .exchange();
     }
 

--- a/src/test/java/com/dnastack/gatekeeper/acl/GatekeeperGatewayFilterFactoryTest.java
+++ b/src/test/java/com/dnastack/gatekeeper/acl/GatekeeperGatewayFilterFactoryTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import static com.dnastack.gatekeeper.acl.GatekeeperGatewayFilterFactory.computeOutboundPath;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class GatekeeperGatewayFilterFactoryTest {
@@ -23,7 +24,7 @@ public class GatekeeperGatewayFilterFactoryTest {
         accessControlItem.getOutbound().setPath("foo/bar/{path}");
 
         final String path = computeOutboundPath(config, accessControlItem, Map.of("path", "banana/slam"));
-        assertThat(path, equalTo("/foo/bar/banana/slam"));
+        assertEquals(path, "/foo/bar/banana/slam");
     }
 
     @Test
@@ -37,6 +38,6 @@ public class GatekeeperGatewayFilterFactoryTest {
         accessControlItem.getOutbound().setPath("{path}");
 
         final String path = computeOutboundPath(config, accessControlItem, Map.of("path", ""));
-        assertThat(path, equalTo("/"));
+        assertEquals(path, "/");
     }
 }

--- a/src/test/java/com/dnastack/gatekeeper/jwtparser/JwtParserTest.java
+++ b/src/test/java/com/dnastack/gatekeeper/jwtparser/JwtParserTest.java
@@ -37,13 +37,14 @@ public class JwtParserTest {
             throw new AssertionError(ex);
         }
 
-        Jwts.parser()
+        Jwts.parserBuilder()
             .setSigningKeyResolver(new SigningKeyResolverAdapter() {
                 @Override
                 public Key resolveSigningKey(JwsHeader header, Claims claims) {
                     return publicKey;
                 }
             })
+            .build()
             .parse(tokenWithWrongAlgorithm);
     }
 }


### PR DESCRIPTION
Hello @mbarkley, I migrated all features which were deprecated and we used them. Everything except one was pretty straight forward and documented but the one thing is `FilterDefinitionLoader.java`. In javadoc of that class there is note that it was copied from some other class. `ConfigurationUtils.bind` is deprecated so I looked into current version of class from which it was copied previously and used that new part. 